### PR TITLE
Fix auth_required is nil error

### DIFF
--- a/lib/nats_ex/connection.ex
+++ b/lib/nats_ex/connection.ex
@@ -127,7 +127,7 @@ defmodule NatsEx.Connection do
   @spec require_auth?(map) :: boolean
   def require_auth?(info) do
     info
-    |> Map.get("auth_required")
+    |> Map.get("auth_required", false)
   end
 
   @spec get_host_port() :: {String.t(), integer}


### PR DESCRIPTION
When nats server was upgraded to version 1.2.0, nats_ex stopped connecting with an error.
`Unable to connect to NATS server: {:error, {:function_clause, [{NatsEx.Connection, :build_connect_message, [nil], [file: 'lib/nats_ex/connection.ex', line: 140]}, {NatsEx.Connection, :init, 1, [file: 'lib/nats_ex/connection.ex', line: 112]}, {:gen_server, :init_it, 2, [file: 'gen_server.erl', line: 374]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 342]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}`
The reason is that connection.ex can find the parameter auth_required in the query parameters
I have prepared a merge request that fixes the problem